### PR TITLE
remove pure variables

### DIFF
--- a/src/CDCL/Algorithm.hs
+++ b/src/CDCL/Algorithm.hs
@@ -126,12 +126,11 @@ cdcl'
   -> Bool
   -> Integer
   -> CDCLResult
-cdcl' aMap (Level lvl) tlist mappedTL clistOG learnedClist learnedClauses confClauses clist period conflictIteration upperBoundary currentBoundary stats fullStats restarts
+cdcl' aMap (Level lvl)  tlist mappedTL clistOG learnedClist learnedClauses confClauses clist period conflictIteration upperBound currentBoundary stats fullStats restarts
 
     -- First and Second Case are part of Restart Algorithm with Luby Sequence
-    -- current conflictiteration has same value like the current upper boundary. 
-    -- Restart the algorithm with higher upper boundary !!
-    | conflictIteration == upperBoundary = cdcl' (initialActivity clistOG Map.empty)
+    -- current conflictiteration has same value like the current upper boundary. Restart the algorithm with higher upper boundary
+    | conflictIteration == upperBound = cdcl' (initialActivity clistOG Map.empty)
                                               (Level 0)
                                               []
                                               Map.empty
@@ -142,14 +141,13 @@ cdcl' aMap (Level lvl) tlist mappedTL clistOG learnedClist learnedClauses confCl
                                               learnedClist
                                               hardCoded
                                               0
-                                              (upperBoundary * 2)
+                                              (upperBound*2)
                                               startBoundary
                                               stats
                                               fullStats
                                               (restarts + 1)
 
-    -- current conflictiteration has same value like the current restart boundary. 
-    -- Restarts the algorithm with higher current boundary !!
+    -- current conflictiteration has same value like the current restart boundary. Restarts the algorithm with higher current boundary
     | conflictIteration == currentBoundary = cdcl' (initialActivity clistOG Map.empty)
                                                    (Level 0)
                                                    []
@@ -161,7 +159,7 @@ cdcl' aMap (Level lvl) tlist mappedTL clistOG learnedClist learnedClauses confCl
                                                    learnedClist
                                                    hardCoded
                                                    0
-                                                   upperBoundary
+                                                   upperBound
                                                    (currentBoundary * 2)
                                                    stats
                                                    fullStats
@@ -186,7 +184,7 @@ cdcl' aMap (Level lvl) tlist mappedTL clistOG learnedClist learnedClauses confCl
                            (makeTupleClauseListFromAnalyze analyzed))
                            periodUpdate2
                            (conflictIteration + 1)
-                           upperBoundary
+                           upperBound
                            currentBoundary
                            stats
                            fullStats
@@ -211,7 +209,7 @@ cdcl' aMap (Level lvl) tlist mappedTL clistOG learnedClist learnedClauses confCl
                         (calculateClauseList (getClauseListFromTriTuple res) list)
                         periodUpdate2
                         conflictIteration
-                        upperBoundary
+                        upperBound
                         currentBoundary
                         stats
                         fullStats

--- a/src/CDCL/Algorithm.hs
+++ b/src/CDCL/Algorithm.hs
@@ -43,6 +43,7 @@ import           Data.Maybe
 hardCoded = Period 30
 startBoundary = 20
 
+
 encodeTuple :: Tuple -> Int
 encodeTuple (Lit l, BTrue) = fromInteger l
 encodeTuple (Lit l, BFalse) = fromInteger (-l)
@@ -70,11 +71,11 @@ solve t = case result of
 --   Function will immediately return SAT if ClauseList is null or UNSAT if an empty List is found within clist
 cdcl :: [[Integer]] -> Bool -> Bool -> CDCLResult
 cdcl clist stats fullStats = case result of 
-            SAT l                             -> SAT (l ++ decodedPureVals)
-            SAT_WITH_STATS l a0 a1 a2 a3         -> SAT_WITH_STATS (l ++ decodedPureVals) a0 a1 a2 a3
+            SAT l                                   -> SAT (l ++ decodedPureVals)
+            SAT_WITH_STATS l a0 a1 a2 a3            -> SAT_WITH_STATS (l ++ decodedPureVals) a0 a1 a2 a3
             SAT_WITH_FULL_STATS l a0 a1 a2 a3 a4 a5 -> SAT_WITH_FULL_STATS (l ++ decodedPureVals) a0 a1 a2 a3 a4 a5
-            UNSAT                             -> UNSAT
-            UNSAT_WITH_STATS a0 a1            -> UNSAT_WITH_STATS a0 a1
+            UNSAT                                   -> UNSAT
+            UNSAT_WITH_STATS a0 a1                  -> UNSAT_WITH_STATS a0 a1
             where (reducedTerm, pureVars) = rmPureVars clist
                   decodedPureVals = map decodeTuple pureVars
                   result = _cdcl reducedTerm False False
@@ -117,32 +118,23 @@ _cdcl clist stats fullStats
 --   After that the recursion starts again with Unitpropagation.
 --   This happens until either SAT or UNSAT is returned as result.
 cdcl'
-  :: ActivityMap -- aMap : ActivityMap :: Literal -> Activity 
-  -> Level -- (Level lvl)
-  -> TupleClauseList -- tlist : Tuple Clause List
-  -> MappedTupleList -- mappedTL : Mapped Tuple Clause List
-  -> ClauseList -- clistOG : Clause List in Original Form
-  -> ClauseList -- learnedClist
-  -> [Clause] -- learnedClauses
-  -> [Clause] -- confClauses
-  -> ClauseList -- clist : ClauseList :: [
-                --                          ReducedClauseAndOGClause :: (
-                --                              Clause :: [Literal :: Lit Integer]    -- Clause reduced with Unitresolution
-                --                              , Clause :: [Literal :: Lit Integer]  -- Clause in its original form
-                --                          )
-                --                       ]
-  -> Period -- period
-  -> Integer -- conflictIteration : Counts the conficts. 
-             --                         if conflictIteration == upperBoundary
-             --                             or conflictIteration == currentBoundary
-             --                         then the algorithm will be restarted 
-             --                             with higher upperBoundary currentBoundary. 
-  -> Integer -- upperBoundary
-  -> Integer -- currentBoundary
-  -> Bool -- stats
-  -> Bool -- fullStats
-  -> Integer -- restarts
-  -> CDCLResult -- result
+  :: ActivityMap
+  -> Level
+  -> TupleClauseList
+  -> MappedTupleList
+  -> ClauseList
+  -> ClauseList
+  -> [Clause]
+  -> [Clause]
+  -> ClauseList
+  -> Period
+  -> Integer
+  -> Integer
+  -> Integer
+  -> Bool
+  -> Bool
+  -> Integer
+  -> CDCLResult
 cdcl' aMap (Level lvl) tlist mappedTL clistOG learnedClist learnedClauses confClauses clist period conflictIteration upperBoundary currentBoundary stats fullStats restarts
 
     -- First and Second Case are part of Restart Algorithm with Luby Sequence

--- a/src/CDCL/Algorithm.hs
+++ b/src/CDCL/Algorithm.hs
@@ -48,10 +48,6 @@ encodeTuple :: Tuple -> Int
 encodeTuple (Lit l, BTrue) = fromInteger l
 encodeTuple (Lit l, BFalse) = fromInteger (-l)
 
-decodeTuple :: Int -> Tuple
-decodeTuple i = if i < 0 then (Lit l, BFalse) else (Lit l, BTrue) 
-    where l = toInteger i
-
 -- | This function calls the solver without reporting any statistics. Returns
 -- list of literanls encoded as Integer.
 solve :: [[Integer]] -> SATResult

--- a/src/CDCL/Algorithm.hs
+++ b/src/CDCL/Algorithm.hs
@@ -69,9 +69,9 @@ solve t = case result of
 cdcl :: [[Integer]] -> Bool -> Bool -> Bool -> CDCLResult
 cdcl clist valuation stats fullStats
     | checked = UNSAT
-    | null reducedTerm && fullStats = SAT_WITH_FULL_STATS [] Map.empty [] 0 0 0 0
-    | null reducedTerm && stats = SAT_WITH_STATS [] 0 0 0 0
-    | null reducedTerm = SAT --[] Map.empty 0
+    | null clist && fullStats = SAT_WITH_FULL_STATS [] Map.empty [] 0 0 0 0
+    | null clist && stats = SAT_WITH_STATS [] 0 0 0 0
+    | null clist = SAT --[] Map.empty 0
     | otherwise = case (valuation, result) of
                     (False, SAT_SOLUTION _)                    -> SAT
                     (False, SAT_WITH_STATS _ _ _ _ _)          -> SAT

--- a/src/CDCL/Algorithm.hs
+++ b/src/CDCL/Algorithm.hs
@@ -60,10 +60,10 @@ solve t = case result of
             UNSAT_WITH_STATS _ _              -> Unsatisfiable
             where result = cdcl t True False False
 
--- | This function will start the Conflict-Driven Clause Learning (CDCL) Procedure.
+-- | This function will start the CDCL Procedure.
 --   To call this function do for example:
---   cdcl [[1,2,3],[2,5]] False False
---   cdcl [[1,2,3,4], [2,4], [4,5],[3,6,7],[3,9,1],[3,8,10]] False False
+--   cdcl [[1,2,3],[2,5]]
+--   cdcl [[1,2,3,4], [2,4], [4,5],[3,6,7],[3,9,1],[3,8,10]]
 --   The function will return the result of the cdcl' function.
 --   Function will immediately return SAT if ClauseList is null or UNSAT if an empty List is found within clist
 cdcl :: [[Integer]] -> Bool -> Bool -> Bool -> CDCLResult

--- a/src/CDCL/DPLL.hs
+++ b/src/CDCL/DPLL.hs
@@ -1,0 +1,50 @@
+{-# OPTIONS_GHC -Wno-incomplete-patterns #-}
+
+module CDCL.DPLL (rmPureVars, getPureVars, isPureVar, rmVars) where
+
+import Data.Set
+
+rmPureVars :: [[Integer]] -> ([[Integer]], [Int])
+rmPureVars term = rmPureVars' (term, [])
+
+rmPureVars' :: ([[Integer]], [Int]) -> ([[Integer]], [Int])
+rmPureVars' t = if t == t' then t else rmPureVars' t'
+    where t' = rmPureVars'' t
+
+rmPureVars'' :: ([[Integer]], [Int]) -> ([[Integer]], [Int])
+rmPureVars'' (term, removedVars) = (reduzedTerm, removedVars ++ pureVars)
+    where pureVars = getPureVars term
+          reduzedTerm = rmVars term pureVars
+
+getPureVars :: [[Integer]] -> [Int]
+getPureVars term = result
+    where pureVars = getPureVars' term term -- get pureVars
+          set = fromList pureVars --remove duplicates
+          result = toList set
+
+getPureVars' :: [[Integer]] -> [[Integer]] -> [Int]
+getPureVars' _ [] = []
+getPureVars' fullerm (x:xs) = getPureVars'' fullerm x ++ getPureVars' fullerm xs
+
+
+getPureVars'' :: [[Integer]] -> [Integer] -> [Int]
+getPureVars'' _ [] = []
+getPureVars'' fullerm (x:xs) = [i | isPureVar fullerm x] ++ getPureVars'' fullerm xs
+    where i = fromIntegral x
+
+isPureVar :: [[Integer]] -> Integer -> Bool
+isPureVar [] _ = True
+isPureVar (x:xs) var = (not (containsVar x (-var))) && isPureVar xs var
+
+containsVar :: [Integer] -> Integer -> Bool
+containsVar [] _ = False
+containsVar (x:xs) var = (x == var) || containsVar xs var
+
+rmVars :: [[Integer]] -> [Int] -> [[Integer]]
+rmVars term [] = term
+rmVars term (x:xs) = rmVars (rmVar term x ) xs
+
+rmVar :: [[Integer]] -> Int -> [[Integer]]
+rmVar [] _ = []
+rmVar (x:xs) var = [x | not (containsVar x i)] ++ rmVar xs var
+    where i = toInteger var

--- a/src/CDCL/DPLL.hs
+++ b/src/CDCL/DPLL.hs
@@ -1,6 +1,6 @@
 {-# OPTIONS_GHC -Wno-incomplete-patterns #-}
 
-module CDCL.DPLL (rmPureVars, getPureVars, isPureVar, rmVars) where
+module CDCL.DPLL (rmPureVars) where
 
 import Data.Set
 

--- a/src/CDCL/DPLL.hs
+++ b/src/CDCL/DPLL.hs
@@ -26,7 +26,6 @@ getPureVars' :: [[Integer]] -> [[Integer]] -> [Int]
 getPureVars' _ [] = []
 getPureVars' fullerm (x:xs) = getPureVars'' fullerm x ++ getPureVars' fullerm xs
 
-
 getPureVars'' :: [[Integer]] -> [Integer] -> [Int]
 getPureVars'' _ [] = []
 getPureVars'' fullerm (x:xs) = [i | isPureVar fullerm x] ++ getPureVars'' fullerm xs
@@ -34,17 +33,12 @@ getPureVars'' fullerm (x:xs) = [i | isPureVar fullerm x] ++ getPureVars'' fuller
 
 isPureVar :: [[Integer]] -> Integer -> Bool
 isPureVar [] _ = True
-isPureVar (x:xs) var = (not (containsVar x (-var))) && isPureVar xs var
-
-containsVar :: [Integer] -> Integer -> Bool
-containsVar [] _ = False
-containsVar (x:xs) var = (x == var) || containsVar xs var
+isPureVar (x:xs) var = (-var) `notElem` x && isPureVar xs var
 
 rmVars :: [[Integer]] -> [Int] -> [[Integer]]
-rmVars term [] = term
-rmVars term (x:xs) = rmVars (rmVar term x ) xs
+rmVars = Prelude.foldl rmVar
 
 rmVar :: [[Integer]] -> Int -> [[Integer]]
 rmVar [] _ = []
-rmVar (x:xs) var = [x | not (containsVar x i)] ++ rmVar xs var
+rmVar (x:xs) var = [x | i `notElem` x] ++ rmVar xs var
     where i = toInteger var

--- a/src/CDCL/DPLL.hs
+++ b/src/CDCL/DPLL.hs
@@ -4,7 +4,12 @@ module CDCL.DPLL (rmPureVars) where
 
 import Data.Set
 
-rmPureVars :: [[Integer]] -> ([[Integer]], [Int])
+-- | This function removes all clauses that contains pure variables
+--   and thus that become pure due to reductions.
+--   It retruns te reduced term and a list of pure variables
+rmPureVars 
+    :: [[Integer]]          -- ^ The '[[Integer]]' argument repesents the input term.
+    -> ([[Integer]], [Int]) -- ^ The '([[Integer]], [Int])' result repesents the reduced term as the first element and the pure vars as the second element.
 rmPureVars term = rmPureVars' (term, [])
 
 rmPureVars' :: ([[Integer]], [Int]) -> ([[Integer]], [Int])
@@ -16,6 +21,8 @@ rmPureVars'' (term, removedVars) = (reduzedTerm, removedVars ++ pureVars)
     where pureVars = getPureVars term
           reduzedTerm = rmVars term pureVars
 
+-- | This function finds all pure varibales in a given term.
+--   It a list of pure variables
 getPureVars :: [[Integer]] -> [Int]
 getPureVars term = result
     where pureVars = getPureVars' term term -- get pureVars
@@ -31,13 +38,16 @@ getPureVars'' _ [] = []
 getPureVars'' fullerm (x:xs) = [i | isPureVar fullerm x] ++ getPureVars'' fullerm xs
     where i = fromIntegral x
 
+-- | This function decides if a given variable is pure in the given term.
 isPureVar :: [[Integer]] -> Integer -> Bool
 isPureVar [] _ = True
 isPureVar (x:xs) var = (-var) `notElem` x && isPureVar xs var
 
+-- | This function finds removesall all clauses that contains the given pure variables.
 rmVars :: [[Integer]] -> [Int] -> [[Integer]]
 rmVars = Prelude.foldl rmVar
 
+-- | This function finds removesall all clauses that contains the given pure variable.
 rmVar :: [[Integer]] -> Int -> [[Integer]]
 rmVar [] _ = []
 rmVar (x:xs) var = [x | i `notElem` x] ++ rmVar xs var

--- a/src/CDCL/Types.hs
+++ b/src/CDCL/Types.hs
@@ -74,11 +74,7 @@ data BoolVal =
     |
         -- | Valuewise -1
         BNothing
-    deriving (Eq, Ord)
-instance Show BoolVal where
-    show BFalse = "False"
-    show BTrue = "True"
-    show BNothing = "Noting"
+    deriving (Show, Eq, Ord)
 
 -- | Datatype for InterpResult
 data InterpretResult =

--- a/src/CDCL/Types.hs
+++ b/src/CDCL/Types.hs
@@ -74,7 +74,11 @@ data BoolVal =
     |
         -- | Valuewise -1
         BNothing
-    deriving (Show, Eq, Ord)
+    deriving (Eq, Ord)
+instance Show BoolVal where
+    show BFalse = "False"
+    show BTrue = "True"
+    show BNothing = "Noting"
 
 -- | Datatype for InterpResult
 data InterpretResult =
@@ -90,7 +94,10 @@ data InterpretResult =
 
 -- | Literal defined as Integer
 newtype Literal = Lit Integer
-    deriving (Show, Eq, Ord)
+    deriving (Eq, Ord)
+instance Show Literal where
+    show (Lit i) = "'" ++ show i ++ "'"
+
 
 -- | Level is associated with the decision level.
 --   Defined as an Integer

--- a/src/CDCL/Types.hs
+++ b/src/CDCL/Types.hs
@@ -90,10 +90,7 @@ data InterpretResult =
 
 -- | Literal defined as Integer
 newtype Literal = Lit Integer
-    deriving (Eq, Ord)
-instance Show Literal where
-    show (Lit i) = "'" ++ show i ++ "'"
-
+    deriving (Show, Eq, Ord)
 
 -- | Level is associated with the decision level.
 --   Defined as an Integer

--- a/test/DPLLSpec.hs
+++ b/test/DPLLSpec.hs
@@ -1,0 +1,17 @@
+module DPLLSpec where
+import           Test.Hspec
+import           CDCL.DPLL (rmPureVars)
+
+spec :: Spec
+spec = do
+    describe "rmPureVars" $ do
+        it "Empty List" $ do
+            rmPureVars [] `shouldBe` ([], [])
+        it "Singleton List" $ do
+            rmPureVars [[]] `shouldBe` ([[]], [])
+        it "Filled List 1" $ do
+            rmPureVars [[1,2,3],[1]] `shouldBe` ([], [1,2,3])
+        it "Filled List 2" $ do
+            rmPureVars [[1,2,3],[-1]] `shouldBe` ([], [2,3,-1])
+        it "Filled List 3" $ do
+            rmPureVars [[1,2,3],[-1],[1]] `shouldBe` ([[-1],[1]], [2,3])


### PR DESCRIPTION
Implemented a function that removes at the begin of cdcl all pure variables and assigns values to them.
This modification improves the performance of the cadp.inria.fr/ftp/benchmarks/vlsat/vlsat1_135_510.cnf bench from around 700  to 5 seconds.