### PR TITLE
Restore functionality of SMT / UF example 

### DIFF
--- a/src/CDCL/Algorithm.hs
+++ b/src/CDCL/Algorithm.hs
@@ -71,15 +71,15 @@ cdcl clist valuation stats fullStats
     | checked = UNSAT
     | null clist && fullStats = SAT_WITH_FULL_STATS [] Map.empty [] 0 0 0 0
     | null clist && stats = SAT_WITH_STATS [] 0 0 0 0
-    | null clist = SAT --[] Map.empty 0
+    | null clist && valuation = SAT_SOLUTION [] --[] Map.empty 0
+    | null clist = SAT
     | otherwise = case (valuation, result) of
-                    (False, SAT_SOLUTION _)                    -> SAT
-                    (False, SAT_WITH_STATS _ _ _ _ _)          -> SAT
-                    (False, SAT_WITH_FULL_STATS _ _ _ _ _ _ _) -> SAT
-                    _                                          -> result
-    where (reducedTerm, _) = rmPureVars clist
-          checked = any null reducedTerm
-          transformedList = transformClauseList reducedTerm
+                    (False, SAT_SOLUTION        {}) -> SAT
+                    (False, SAT_WITH_STATS      {}) -> SAT
+                    (False, SAT_WITH_FULL_STATS {}) -> SAT
+                    _                               -> result
+    where checked = any null clist
+          transformedList = transformClauseList clist
           aMap = initialActivity transformedList Map.empty
           result = cdcl'
                   aMap

--- a/src/CDCL/Algorithm.hs
+++ b/src/CDCL/Algorithm.hs
@@ -36,7 +36,7 @@ import           CDCL.MapLogic (pushToMappedTupleList)
 
 import           CDCL.Conflict (analyzeConflict)
 import           CDCL.DPLL (rmPureVars)
- 
+
 import qualified Data.Map.Strict as Map
 import           Data.Maybe
 
@@ -109,23 +109,32 @@ cdcl clist valuation stats fullStats
 --   After that the recursion starts again with Unitpropagation.
 --   This happens until either SAT or UNSAT is returned as result.
 cdcl'
-  :: ActivityMap
-  -> Level
-  -> TupleClauseList
-  -> MappedTupleList
-  -> ClauseList
-  -> ClauseList
-  -> [Clause]
-  -> [Clause]
-  -> ClauseList
-  -> Period
-  -> Integer
-  -> Integer
-  -> Integer
-  -> Bool
-  -> Bool
-  -> Integer
-  -> CDCLResult
+  :: ActivityMap -- aMap : ActivityMap :: Literal -> Activity
+  -> Level -- (Level lvl)
+  -> TupleClauseList -- tlist : Tuple Clause List
+  -> MappedTupleList -- mappedTL : Mapped Tuple Clause List
+  -> ClauseList -- clistOG : Clause List in Original Form
+  -> ClauseList -- learnedClist
+  -> [Clause] -- learnedClauses
+  -> [Clause] -- confClauses
+  -> ClauseList -- clist : ClauseList :: [
+                --                          ReducedClauseAndOGClause :: (
+                --                              Clause :: [Literal :: Lit Integer]    -- Clause reduced with Unitresolution
+                --                              , Clause :: [Literal :: Lit Integer]  -- Clause in its original form
+                --                          )
+                --                       ]
+  -> Period -- period
+  -> Integer -- conflictIteration : Counts the conficts.
+             --                         if conflictIteration == upperBoundary
+             --                             or conflictIteration == currentBoundary
+             --                         then the algorithm will be restarted
+             --                             with higher upperBoundary currentBoundary.
+  -> Integer -- upperBoundary
+  -> Integer -- currentBoundary
+  -> Bool -- stats
+  -> Bool -- fullStats
+  -> Integer -- restarts
+  -> CDCLResult -- result
 cdcl' aMap (Level lvl)  tlist mappedTL clistOG learnedClist learnedClauses confClauses clist period conflictIteration upperBound currentBoundary stats fullStats restarts
 
     -- First and Second Case are part of Restart Algorithm with Luby Sequence

--- a/test/AlgorithmSpec.hs
+++ b/test/AlgorithmSpec.hs
@@ -15,7 +15,12 @@ spec :: Spec
 spec = do
     describe "Compare with picoSAT solver" $ do
         it "compare SAT / UNSAT result term reduced to empty list" $ do
-          prop_picoSATcomparison [[NonZero 1, NonZero 2],[NonZero (-1)]]
+          let problem = [[1, 2], [- 1]]
+              csol = cdcl (map (map fromIntegral) problem) False False False
+          psol <- PicoSAT.solve problem
+          (case (psol, csol) of
+             (PicoSAT.Solution _, SAT) -> True
+             _                          -> False) `shouldBe` True
         it "compare SAT / UNSAT results" $ do
           property $ \clauses -> prop_picoSATcomparison clauses
 

--- a/test/AlgorithmSpec.hs
+++ b/test/AlgorithmSpec.hs
@@ -29,8 +29,8 @@ prop_picoSATcomparison cl = withMaxSuccess 10000 ( monadicIO ( do
   let clauses = coerce cl
   picoSol <- run (PicoSAT.solve clauses)
   let cdclSol = cdcl (map (map fromIntegral) clauses) False False False
-  assert ( case (picoSol, cdclSol) of
-             (PicoSAT.Unsatisfiable, UNSAT) -> True
-             (PicoSAT.Unknown, _)           -> False
-             (PicoSAT.Solution _, SAT)      -> True
-             _                              -> False )))
+  ( case (picoSol, cdclSol) of
+      (PicoSAT.Unsatisfiable, UNSAT) -> pure $ collect "UNSAT"   True
+      (PicoSAT.Unknown, _)           -> pure $ collect "Unknown" False
+      (PicoSAT.Solution _, SAT)      -> pure $ collect "SAT"     True
+      _                              -> pure $ collect "no Idea" False )))


### PR DESCRIPTION
~Tests do not yet work~
```
Algorithm                                                                                     
  Compare with picoSAT solver                                                                 
    compare SAT / UNSAT result term reduced to empty list FAILED [1]
    compare SAT / UNSAT results FAILED [2]     
```
Tests fixed
- first test made unit test
- second test collects results